### PR TITLE
Incorrect Tag Version for Keyword Spotting Code Example

### DIFF
--- a/edgeimpulse-ce-manifest-fv2.xml
+++ b/edgeimpulse-ce-manifest-fv2.xml
@@ -32,8 +32,8 @@
         <commit>release-v2.0.0</commit>
       </version>
       <version flow_version="2.0" tools_min_version="2.4.0" tools_max_version="2.4.1" req_capabilities_per_version="bsp_gen3">
-        <num>1.0.3 release</num>
-        <commit>release-v1.0.3</commit>
+        <num>1.0.0 release</num>
+        <commit>release-v1.0.0</commit>
       </version>
     </versions>
   </app>


### PR DESCRIPTION
The manifest specifies a commit version of `release-v1.0.3` for the code example [mtb-example-edgeimpulse-keyword-spotting](https://github.com/edgeimpulse/mtb-example-edgeimpulse-keyword-spotting/tags) which does not exist. This should have been `release-v1.0.0`. This PR fixes this issue.

Please run the following command when using the [mtb-manifest-checker](https://github.com/Infineon/mtb-manifest-checker) to identify formatting and asset issues like this one to prevent this from occurring in the future. 
`>> ./mtb_manifest_checker.sh apps/edgeimpulse-ce-manifest-fv2.xml`

@faradayberry  can you please look into this?